### PR TITLE
Replace lexical-let* with let*

### DIFF
--- a/magit-reviewboard.el
+++ b/magit-reviewboard.el
@@ -224,20 +224,20 @@ See `magit-section-match'.  Also delete it from root section's children."
   "Scan for review-requests with magit-reviewboard-scan-reviews and insert the contents into MAGIT-STATUS-BUFFER.
 MAGIT-STATUS-BUFFER is what it says.  DIRECTORY is the directory in which to run the scan."
   (when (magit-get-remote)
-    (lexical-let* ((upstream-url (magit-get nil (format "remote.%s.url" (substring-no-properties (magit-get-remote)))))
-                   (proc (request
-                          (magit-reviewboard-uri "/repositories/")
-                          :type "GET"
-                          :params '(("max-results" . "200"))
-                          :parser 'json-read
-                          :headers '(("Content-Type" . "application/json"))))
-                   (done (while (not (request-response-done-p proc)) (sleep-for .1)))
-                   (data (request-response-data proc))
-                   (repos (assoc-default 'repositories data))
-                   (repo-id (cl-loop for repo across repos
-                                     when (cl-search (assoc-default 'path repo) upstream-url)
-                                     return (assoc-default 'id repo)))
-                   (magit-status-buffer magit-status-buffer))
+    (let* ((upstream-url (magit-get nil (format "remote.%s.url" (substring-no-properties (magit-get-remote)))))
+           (proc (request
+                  (magit-reviewboard-uri "/repositories/")
+                  :type "GET"
+                  :params '(("max-results" . "200"))
+                  :parser 'json-read
+                  :headers '(("Content-Type" . "application/json"))))
+           (_done (while (not (request-response-done-p proc)) (sleep-for .1)))
+           (data (request-response-data proc))
+           (repos (assoc-default 'repositories data))
+           (repo-id (cl-loop for repo across repos
+                             when (cl-search (assoc-default 'path repo) upstream-url)
+                             return (assoc-default 'id repo)))
+           (magit-status-buffer magit-status-buffer))
       (if repo-id (request
        (magit-reviewboard-uri "/review-requests/")
        :type "GET"


### PR DESCRIPTION
Because this package enables lexical-binding. And this fixes following byte-compile warnings.

```
magit-reviewboard.el:269:30:Warning: ‘(upstream-url (magit-get nil (format
    "remote.%s.url" (substring-no-properties (magit-get-remote)))))’ is a
    malformed function
magit-reviewboard.el:235:49:Warning: reference to free variable ‘proc’
magit-reviewboard.el:249:32:Warning: reference to free variable ‘data’
magit-reviewboard.el:246:35:Warning: reference to free variable ‘repos’
magit-reviewboard.el:272:18:Warning: reference to free variable ‘upstream-url’
magit-reviewboard.el:266:55:Warning: reference to free variable ‘repo-id’

In end of data:
magit-reviewboard.el:486:1:Warning: the following functions are not known to be defined: lexical-let*,
    proc, done, data, repos, repo-id, magit-status-buffer
```